### PR TITLE
cpp interop changes - drop _Bool, use portable popcount and highest_bit_position implementations

### DIFF
--- a/buddy_alloc.h
+++ b/buddy_alloc.h
@@ -16,7 +16,6 @@
 #define BUDDY_ALLOC_H
 
 #include <limits.h>
-#include <stdalign.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/buddy_alloc.h
+++ b/buddy_alloc.h
@@ -485,7 +485,7 @@ void *buddy_realloc(struct buddy *buddy, void *ptr, size_t requested_size) {
     }
 
     /* Find the position tracking this address */
-    buddy_tree_pos origin = position_for_address(buddy, ptr);
+    buddy_tree_pos origin = position_for_address(buddy, (unsigned char *) ptr);
     if (!origin) {
         return NULL;
     }

--- a/tests.c
+++ b/tests.c
@@ -44,9 +44,9 @@ void test_bitset_basic() {
 	assert(bitset_sizeof(7) == 1);
 	assert(bitset_sizeof(8) == 1);
 	assert(bitset_sizeof(9) == 2);
-	assert(bitset_test(buf, 0) == 0);
+	assert(!bitset_test(buf, 0));
 	bitset_set(buf, 0);
-	assert(bitset_test(buf, 0) == 1);
+	assert(bitset_test(buf, 0));
 }
 
 void test_bitset_range() {
@@ -86,56 +86,56 @@ void test_bitset_shift() {
 	bitset_set(buf, 4);
 	bitset_set(buf, 7);
 	bitset_shift_right(buf, 0, 8, 4);
-	assert(bitset_test(buf, 0) == 0);
-	assert(bitset_test(buf, 1) == 0);
-	assert(bitset_test(buf, 2) == 0);
-	assert(bitset_test(buf, 3) == 0);
-	assert(bitset_test(buf, 4) == 1);
-	assert(bitset_test(buf, 5) == 0);
-	assert(bitset_test(buf, 6) == 0);
-	assert(bitset_test(buf, 7) == 1);
-	assert(bitset_test(buf, 8) == 1);
-	assert(bitset_test(buf, 9) == 0);
-	assert(bitset_test(buf, 10) == 0);
-	assert(bitset_test(buf, 11) == 1);
-	assert(bitset_test(buf, 12) == 0);
-	assert(bitset_test(buf, 13) == 0);
-	assert(bitset_test(buf, 14) == 0);
-	assert(bitset_test(buf, 15) == 0);
+	assert(!bitset_test(buf, 0));
+	assert(!bitset_test(buf, 1));
+	assert(!bitset_test(buf, 2));
+	assert(!bitset_test(buf, 3));
+	assert(bitset_test(buf, 4));
+	assert(!bitset_test(buf, 5));
+	assert(!bitset_test(buf, 6));
+	assert(bitset_test(buf, 7));
+	assert(bitset_test(buf, 8));
+	assert(!bitset_test(buf, 9));
+	assert(!bitset_test(buf, 10));
+	assert(bitset_test(buf, 11));
+	assert(!bitset_test(buf, 12));
+	assert(!bitset_test(buf, 13));
+	assert(!bitset_test(buf, 14));
+	assert(!bitset_test(buf, 15));
 	bitset_shift_left(buf, 4, 12, 4);
-	assert(bitset_test(buf, 0) == 1);
-	assert(bitset_test(buf, 1) == 0);
-	assert(bitset_test(buf, 2) == 0);
-	assert(bitset_test(buf, 3) == 1);
-	assert(bitset_test(buf, 4) == 1);
-	assert(bitset_test(buf, 5) == 0);
-	assert(bitset_test(buf, 6) == 0);
-	assert(bitset_test(buf, 7) == 1);
-	assert(bitset_test(buf, 8) == 0);
-	assert(bitset_test(buf, 9) == 0);
-	assert(bitset_test(buf, 10) == 0);
-	assert(bitset_test(buf, 11) == 0);
-	assert(bitset_test(buf, 12) == 0);
-	assert(bitset_test(buf, 13) == 0);
-	assert(bitset_test(buf, 14) == 0);
-	assert(bitset_test(buf, 15) == 0);
+	assert(bitset_test(buf, 0));
+	assert(!bitset_test(buf, 1));
+	assert(!bitset_test(buf, 2));
+	assert(bitset_test(buf, 3));
+	assert(bitset_test(buf, 4));
+	assert(!bitset_test(buf, 5));
+	assert(!bitset_test(buf, 6));
+	assert(bitset_test(buf, 7));
+	assert(!bitset_test(buf, 8));
+	assert(!bitset_test(buf, 9));
+	assert(!bitset_test(buf, 10));
+	assert(!bitset_test(buf, 11));
+	assert(!bitset_test(buf, 12));
+	assert(!bitset_test(buf, 13));
+	assert(!bitset_test(buf, 14));
+	assert(!bitset_test(buf, 15));
 }
 
 void test_bitset_shift_invalid() {
 	start_test;
 	unsigned char buf[4096] = {0};
 	bitset_set_range(buf, 1, 0); /* no-op */
-	assert(bitset_test(buf, 0) == 0);
-	assert(bitset_test(buf, 1) == 0);
+	assert(!bitset_test(buf, 0));
+	assert(!bitset_test(buf, 1));
 	bitset_set_range(buf, 0, 1);
-	assert(bitset_test(buf, 0) == 1);
-	assert(bitset_test(buf, 1) == 1);
+	assert(bitset_test(buf, 0));
+	assert(bitset_test(buf, 1));
 	bitset_clear_range(buf, 1, 0) /* no-op */;
-	assert(bitset_test(buf, 0) == 1);
-	assert(bitset_test(buf, 1) == 1);
+	assert(bitset_test(buf, 0));
+	assert(bitset_test(buf, 1));
 	bitset_clear_range(buf, 0, 1);
-	assert(bitset_test(buf, 0) == 0);
-	assert(bitset_test(buf, 1) == 0);
+	assert(!bitset_test(buf, 0));
+	assert(!bitset_test(buf, 1));
 }
 
 void test_bitset_debug() {

--- a/tests.c
+++ b/tests.c
@@ -38,6 +38,12 @@ void test_ceiling_power_of_two() {
 	assert(ceiling_power_of_two(8) == 8);
 }
 
+void test_popcount_byte() {
+	for (size_t i = 0; i < 256; i++) {
+		assert(popcount_byte(i) == (popcount_byte(i / 2) + (i & 1)));
+	}
+}
+
 void test_bitset_basic() {
 	start_test;
 	unsigned char buf[4] = {0};
@@ -1336,6 +1342,7 @@ int main() {
 	{
 		test_highest_bit_position();
 		test_ceiling_power_of_two();
+		test_popcount_byte();
 	}
 
 	{


### PR DESCRIPTION
Fixes #13 
