### PR TITLE
Introduce buddy_malloc_firstfit, drop left_bias/optimal modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ check-recursion: $(LIB_SRC)
 	[ $$( cflow --no-main $(LIB_SRC) | grep -c 'recursive:' ) -eq "0" ]
 
 clean:
-	rm -f a.out *.gcda *.gcno *.gcov tests.out
+	rm -f a.out *.gcda *.gcno *.gcov tests.out bench
 
 .PHONY: test clean test-clang-tidy test-cppcheck
 

--- a/bench.c
+++ b/bench.c
@@ -14,7 +14,8 @@
 #include "buddy_alloc.h"
 #undef BUDDY_ALLOC_IMPLEMENTATION
 
-double test(size_t alloc_size);
+double test_malloc(size_t alloc_size);
+double test_malloc_firstfit(size_t alloc_size);
 void *freeing_callback(void *ctx, void *addr, size_t slot_size);
 
 int main() {
@@ -22,13 +23,18 @@ int main() {
 
 	double total = 0;
 	for (size_t i = 0; i <= 6; i++) {
-		total += test(64 << i);
+		total += test_malloc(64 << i);
 	}
-	
-	printf("Total runtime was %f seconds.\n", total);	
+	printf("Total malloc runtime was %f seconds.\n\n", total);
+
+	total = 0;
+	for (size_t i = 0; i <= 6; i++) {
+		total += test_malloc_firstfit(64 << i);
+	}
+	printf("Total walk malloc runtime was %f seconds.\n\n", total);
 }
 
-double test(size_t alloc_size) {
+double test_malloc(size_t alloc_size) {
 
 	size_t arena_size = 1 << 30;
 	unsigned char *buddy_buf = malloc(buddy_sizeof(arena_size));
@@ -42,6 +48,40 @@ double test(size_t alloc_size) {
 		// fill it up
 	}
 	time_t alloc_time = time(NULL);
+
+	assert(buddy_is_full(buddy));
+
+	buddy_walk(buddy, freeing_callback, buddy);
+	assert(buddy_is_empty(buddy));
+
+	time_t end_time = time(NULL);
+	double delta = difftime(end_time, start_time);
+	printf("Test took %.f seconds in total. Allocation: %.f freeing: %.f\n", delta,
+		difftime(alloc_time, start_time), difftime(end_time, alloc_time));
+
+	free(data_buf);
+	free(buddy_buf);
+
+	return delta;
+}
+
+double test_malloc_firstfit(size_t alloc_size) {
+
+	size_t arena_size = 1 << 30;
+	unsigned char *buddy_buf = malloc(buddy_sizeof(arena_size));
+	unsigned char *data_buf = malloc(arena_size);
+	struct buddy *buddy = buddy_init(buddy_buf, data_buf, arena_size);
+
+	printf("Starting test with alloc size [%zu].\n", alloc_size);
+	time_t start_time = time(NULL);
+
+	while (buddy_malloc_firstfit(buddy, alloc_size)) {
+		// fill it up
+	}
+	time_t alloc_time = time(NULL);
+
+	assert(buddy_is_full(buddy));
+
 	buddy_walk(buddy, freeing_callback, buddy);
 	assert(buddy_is_empty(buddy));
 


### PR DESCRIPTION
Add a first-fit malloc implementation that uses the buddy tree walk machinery. It's a bit faster than the optimal-fit malloc for small-sized requests.

	$ make bench
	cc -O2 bench.c -o bench
	./bench
	Starting test with alloc size [64].
	Test took 10 seconds in total. Allocation: 8 freeing: 2
	Starting test with alloc size [128].
	Test took 5 seconds in total. Allocation: 4 freeing: 1
	Starting test with alloc size [256].
	Test took 3 seconds in total. Allocation: 2 freeing: 1
	Starting test with alloc size [512].
	Test took 1 seconds in total. Allocation: 1 freeing: 0
	Starting test with alloc size [1024].
	Test took 0 seconds in total. Allocation: 0 freeing: 0
	Starting test with alloc size [2048].
	Test took 1 seconds in total. Allocation: 1 freeing: 0
	Starting test with alloc size [4096].
	Test took 0 seconds in total. Allocation: 0 freeing: 0
	Total malloc runtime was 20.000000 seconds.

	Starting test with alloc size [64].
	Test took 9 seconds in total. Allocation: 7 freeing: 2
	Starting test with alloc size [128].
	Test took 4 seconds in total. Allocation: 3 freeing: 1
	Starting test with alloc size [256].
	Test took 2 seconds in total. Allocation: 2 freeing: 0
	Starting test with alloc size [512].
	Test took 2 seconds in total. Allocation: 1 freeing: 1
	Starting test with alloc size [1024].
	Test took 0 seconds in total. Allocation: 0 freeing: 0
	Starting test with alloc size [2048].
	Test took 0 seconds in total. Allocation: 0 freeing: 0
	Starting test with alloc size [4096].
	Test took 1 seconds in total. Allocation: 0 freeing: 1
	Total walk malloc runtime was 18.000000 seconds.
