### PR TITLE
make #include header and fragmentation calculation optional 

### DIFF
--- a/tests.c
+++ b/tests.c
@@ -576,6 +576,8 @@ void test_buddy_debug(void) {
 	buddy_debug(buddy); /* code coverage */
 	buddy = buddy_init_alignment(buddy_buf, data_buf, 4096, 4096);
 	buddy_debug(buddy); /* code coverage */
+	buddy = buddy_embed(data_buf, 4096);
+	buddy_debug(buddy); /* code coverage */
 	free(buddy_buf);
 }
 


### PR DESCRIPTION
I'm trying to use this library in a linux kernel module for a device driver. I know this project is intended for c99 but kernel module prefers C90 coding style. I also compile this library in user space with a more restricted compiler warning following this page: https://airbus-seclab.github.io/c-compiler-security/. Most of the fix are warning on cast changes alignment, arith-conversion and sign-conversion. 

I send this for reference. You don't need to merge it if you think the changes are out of scope for this project.