### PR TITLE
only include stdio.h when used

### DIFF
--- a/buddy_alloc.h
+++ b/buddy_alloc.h
@@ -19,7 +19,9 @@
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
+#ifndef BUDDY_PRINTF
 #include <stdio.h>
+#endif
 #include <string.h>
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
If we have a customized `BUDDY_PRINTF`, stdio.h can be ignored.

[test and bench](https://envs.sh/20m.txt)