### PR TITLE
Drop amd64_arm from ci/cd until windows builder issue is fixed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        arch: [amd64, amd64_x86, amd64_arm, amd64_arm64]
+        arch: [amd64, amd64_x86, amd64_arm64]
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
<CHANGE SUMMARY>
