### PR TITLE
Fixed a bug in buddy_is_free that could prevent downsizing

### DIFF
--- a/buddy_alloc.h
+++ b/buddy_alloc.h
@@ -1253,7 +1253,7 @@ static bool buddy_is_free(struct buddy *buddy, size_t from) {
     effective_memory_size = buddy_effective_memory_size(buddy);
     virtual_slots = buddy_virtual_slots(buddy);
     to = effective_memory_size -
-        ((virtual_slots ? virtual_slots : 1) * buddy->alignment);
+        ((virtual_slots ? (virtual_slots + 1) : 1) * buddy->alignment);
 
     tree = buddy_tree(buddy);
 


### PR DESCRIPTION
While looking for another bug and using buddy_can_shrink as a signal it turned out that it is not handling virtual slots properly.
