### PR TITLE
Fix a bug in the bitset_shift calculations, resulting in a corrupted state after downsizing the allocator

### DIFF
--- a/buddy_alloc.h
+++ b/buddy_alloc.h
@@ -2055,9 +2055,8 @@ static void bitset_shift_left(unsigned char *bitset, size_t from_pos, size_t to_
         } else {
             bitset_clear(bitset, at-by);
         }
+        bitset_clear(bitset, at);
     }
-    bitset_clear_range(bitset, bitset_range(length, length+by-1));
-
 }
 
 static void bitset_shift_right(unsigned char *bitset, size_t from_pos, size_t to_pos, size_t by) {
@@ -2069,9 +2068,9 @@ static void bitset_shift_right(unsigned char *bitset, size_t from_pos, size_t to
         } else {
             bitset_clear(bitset, at+by);
         }
+        bitset_clear(bitset, at);
         length -= 1;
     }
-    bitset_clear_range(bitset, bitset_range(from_pos, from_pos+by-1));
 }
 
 void bitset_debug(unsigned char *bitset, size_t length) {

--- a/tests.c
+++ b/tests.c
@@ -122,9 +122,6 @@ void test_bitset_range(void) {
 void test_bitset_shift(void) {
     unsigned char *buf = malloc(bitset_sizeof(16));
     START_TEST;
-    for (size_t i = 0; i < bitset_sizeof(16); i++) {
-        buf[i] = 0;
-    }
     for (size_t i = 0; i < 16; i++) {
         bitset_clear(buf, i);
     }
@@ -166,6 +163,18 @@ void test_bitset_shift(void) {
     assert(!bitset_test(buf, 13));
     assert(!bitset_test(buf, 14));
     assert(!bitset_test(buf, 15));
+
+    for (size_t i = 0; i < 16; i++) {
+        bitset_set(buf, i);
+    }
+    bitset_shift_left(buf, 4, 5, 1);
+    for (size_t i = 0; i < 16; i++) {
+        if (i == 4) {
+            assert(!bitset_test(buf, i));
+        } else {
+            assert(bitset_test(buf, i));
+        }
+    }
     free(buf);
 }
 


### PR DESCRIPTION
Closes #128

