### PR TITLE
Rename functions to avoid shadowing default c++ constructor for structs

### DIFF
--- a/buddy_alloc.h
+++ b/buddy_alloc.h
@@ -430,7 +430,7 @@ struct bitset_range {
     uint8_t to_index;
 };
 
-static inline struct bitset_range bitset_range(size_t from_pos, size_t to_pos);
+static inline struct bitset_range to_bitset_range(size_t from_pos, size_t to_pos);
 
 static void bitset_set_range(unsigned char *bitset, struct bitset_range range);
 
@@ -1522,8 +1522,8 @@ static void buddy_tree_grow(struct buddy_tree *t, uint8_t desired_order) {
 
             /* Clear right section */
             bitset_clear_range(buddy_tree_bits(t),
-                bitset_range(next_internal.bitset_location + (next_internal.local_offset * node_count),
-                             next_internal.bitset_location + (next_internal.local_offset * node_count * 2) - 1));
+                to_bitset_range(next_internal.bitset_location + (next_internal.local_offset * node_count),
+                                next_internal.bitset_location + (next_internal.local_offset * node_count * 2) - 1));
 
             /* Handle the upper level */
             current_order -= 1u;
@@ -1676,11 +1676,11 @@ static inline size_t buddy_tree_size_for_order(struct buddy_tree *t,
 
 static void write_to_internal_position(struct buddy_tree* t, struct internal_position pos, size_t value) {
     unsigned char *bitset = buddy_tree_bits(t);
-    struct bitset_range clear_range = bitset_range(pos.bitset_location, pos.bitset_location + pos.local_offset - 1);
+    struct bitset_range clear_range = to_bitset_range(pos.bitset_location, pos.bitset_location + pos.local_offset - 1);
 
     bitset_clear_range(bitset, clear_range);
     if (value) {
-        bitset_set_range(bitset, bitset_range(pos.bitset_location, pos.bitset_location+value-1));
+        bitset_set_range(bitset, to_bitset_range(pos.bitset_location, pos.bitset_location+value-1));
     }
 
 #ifdef BUDDY_EXPERIMENTAL_CHANGE_TRACKING
@@ -1693,7 +1693,7 @@ static size_t read_from_internal_position(unsigned char *bitset, struct internal
     if (! bitset_test(bitset, pos.bitset_location)) {
         return 0; /* Fast test without complete extraction */
     }
-    return bitset_count_range(bitset, bitset_range(pos.bitset_location, pos.bitset_location+pos.local_offset-1));
+    return bitset_count_range(bitset, to_bitset_range(pos.bitset_location, pos.bitset_location+pos.local_offset-1));
 }
 
 static inline unsigned char compare_with_internal_position(unsigned char *bitset, struct internal_position pos, size_t value) {
@@ -2050,7 +2050,7 @@ static const uint8_t bitset_char_mask[8][8] = {
     {0, 0, 0,  0,  0,  0,   0, 128},
 };
 
-static inline struct bitset_range bitset_range(size_t from_pos, size_t to_pos) {
+static inline struct bitset_range to_bitset_range(size_t from_pos, size_t to_pos) {
     struct bitset_range range = {0};
     range.from_bucket = from_pos / CHAR_BIT;
     range.to_bucket = to_pos / CHAR_BIT;

--- a/buddy_alloc.h
+++ b/buddy_alloc.h
@@ -354,7 +354,7 @@ static struct buddy_tree_pos buddy_tree_right_adjacent(struct buddy_tree_pos pos
 static size_t buddy_tree_index(struct buddy_tree_pos pos);
 
 /* Return the interval of the deepest positions spanning the indicated position */
-static struct buddy_tree_interval buddy_tree_interval(struct buddy_tree *t, struct buddy_tree_pos pos);
+static struct buddy_tree_interval to_buddy_tree_interval(struct buddy_tree *t, struct buddy_tree_pos pos);
 
 /* Checks if one interval contains another */
 static bool buddy_tree_interval_contains(struct buddy_tree_interval outer,
@@ -1314,13 +1314,13 @@ static bool buddy_is_free(struct buddy *buddy, size_t from) {
 
     pos = deepest_position_for_offset(buddy, from);
     while(buddy_tree_valid(tree, pos) && (pos.index < query_range.to.index)) {
-        struct buddy_tree_interval current_test_range = buddy_tree_interval(tree, pos);
+        struct buddy_tree_interval current_test_range = to_buddy_tree_interval(tree, pos);
         struct buddy_tree_interval parent_test_range =
-            buddy_tree_interval(tree, buddy_tree_parent(pos));
+            to_buddy_tree_interval(tree, buddy_tree_parent(pos));
         while(buddy_tree_interval_contains(query_range, parent_test_range)) {
             pos = buddy_tree_parent(pos);
             current_test_range = parent_test_range;
-            parent_test_range = buddy_tree_interval(tree, buddy_tree_parent(pos));
+            parent_test_range = to_buddy_tree_interval(tree, buddy_tree_parent(pos));
         }
         /* pos is now tracking an overlapping segment */
         if (! buddy_tree_is_free(tree, pos)) {
@@ -1700,7 +1700,7 @@ static inline unsigned char compare_with_internal_position(unsigned char *bitset
     return bitset_test(bitset, pos.bitset_location+value-1);
 }
 
-static struct buddy_tree_interval buddy_tree_interval(struct buddy_tree *t, struct buddy_tree_pos pos) {
+static struct buddy_tree_interval to_buddy_tree_interval(struct buddy_tree *t, struct buddy_tree_pos pos) {
     struct buddy_tree_interval result;
     size_t depth;
 

--- a/tests.c
+++ b/tests.c
@@ -2529,7 +2529,7 @@ void test_buddy_tree_buddy() {
     struct buddy_tree *tree;
     START_TEST;
     buddy = buddy_embed(buf, 4096);
-    tree = buddy_tree(buddy);
+    tree = buddy_tree_for(buddy);
     assert(buddy_tree_buddy(tree) == buddy);
 }
 

--- a/tests.c
+++ b/tests.c
@@ -108,7 +108,7 @@ void test_bitset_range(void) {
     for (size_t i = 0; i < bitset_length; i++) {
         for (size_t j = 0; j <= i; j++) {
             memset(buf, 0, 4);
-            bitset_set_range(buf, bitset_range(j, i));
+            bitset_set_range(buf, to_bitset_range(j, i));
             for (size_t k = 0; k < bitset_length; k++) {
                 if ((k >= j) && (k <= i)) {
                     assert(bitset_test(buf, k));
@@ -116,7 +116,7 @@ void test_bitset_range(void) {
                     assert(!bitset_test(buf, k));
                 }
             }
-            bitset_clear_range(buf, bitset_range(j, i));
+            bitset_clear_range(buf, to_bitset_range(j, i));
             for (size_t k = j; k < i; k++) {
                 assert(!bitset_test(buf, k));
             }
@@ -186,16 +186,16 @@ void test_bitset_shift(void) {
 void test_bitset_shift_invalid(void) {
     unsigned char buf[4096] = {0};
     START_TEST;
-    bitset_set_range(buf, bitset_range(1, 0)); /* no-op */
+    bitset_set_range(buf, to_bitset_range(1, 0)); /* no-op */
     assert(!bitset_test(buf, 0));
     assert(!bitset_test(buf, 1));
-    bitset_set_range(buf, bitset_range(0, 1));
+    bitset_set_range(buf, to_bitset_range(0, 1));
     assert(bitset_test(buf, 0));
     assert(bitset_test(buf, 1));
-    bitset_clear_range(buf, bitset_range(1, 0)) /* no-op */;
+    bitset_clear_range(buf, to_bitset_range(1, 0)) /* no-op */;
     assert(bitset_test(buf, 0));
     assert(bitset_test(buf, 1));
-    bitset_clear_range(buf, bitset_range(0, 1));
+    bitset_clear_range(buf, to_bitset_range(0, 1));
     assert(!bitset_test(buf, 0));
     assert(!bitset_test(buf, 1));
 }

--- a/tests.c
+++ b/tests.c
@@ -2499,10 +2499,10 @@ void test_buddy_tree_interval(void) {
     START_TEST;
     t = buddy_tree_init(buddy_tree_buf, 3);
     pos = buddy_tree_leftmost_child(t);
-    interval = buddy_tree_interval(t, pos);
+    interval = to_buddy_tree_interval(t, pos);
     assert(interval.from.index == pos.index);
     assert(interval.to.index == pos.index);
-    interval = buddy_tree_interval(t, buddy_tree_parent(pos));
+    interval = to_buddy_tree_interval(t, buddy_tree_parent(pos));
     assert(interval.from.index == pos.index);
     assert(interval.to.index == buddy_tree_right_adjacent(pos).index);
 }
@@ -2515,8 +2515,8 @@ void test_buddy_tree_interval_contains(void) {
     START_TEST;
     t = buddy_tree_init(buddy_tree_buf, 3);
     pos = buddy_tree_leftmost_child(t);
-    interval_low = buddy_tree_interval(t, pos);
-    interval_high = buddy_tree_interval(t, buddy_tree_parent(pos));
+    interval_low = to_buddy_tree_interval(t, pos);
+    interval_high = to_buddy_tree_interval(t, buddy_tree_parent(pos));
     assert(buddy_tree_interval_contains(interval_low, interval_low) == 1);
     assert(buddy_tree_interval_contains(interval_high, interval_low) == 1);
     assert(buddy_tree_interval_contains(interval_high, interval_high) == 1);


### PR DESCRIPTION
When the allocator is used in strict c++ there are warning that these functions were shadowing the default constructors for the same-named structs. Rename the functions to eliminate the warnings. Luckily C has no such issues :)